### PR TITLE
fix for github projects with empty license api field

### DIFF
--- a/layouts/partials/sections/gallery/modals.html
+++ b/layouts/partials/sections/gallery/modals.html
@@ -82,7 +82,7 @@
             {{ with $scratch.Get "repo" }}<div class="row center-xs"><div class="repo-info">
             <a href="{{ .html_url }}/pulse"><span class="icon icon-github-octocat"></span></a>
             <a href="{{ .languages_url }}">{{ .language }}{{ with ($scratch.Get "repo-lang-main") }}{{ if lt . 100.0 }} ({{ . }}%) {{ end }}{{ end }}</a>
-            {{ with .license }}{{ with (getJSON .url) }} &bull; <a href="{{ .html_url }}">{{ .spdx_id }}</a> {{ end }} {{ end }}
+            {{ with .license }}{{ with .url }}{{ with (getJSON .) }} &bull; <a href="{{ .html_url }}">{{ .spdx_id }}</a> {{ end }} {{ end }} {{ end }}
             {{ if gt .stargazers_count 0 }} &bull; <a href="{{ .html_url }}/stargazers"> {{ .stargazers_count }} stars </a>{{ end }}
             {{ if gt .forks_count 0 }} &bull; <a href="{{ .html_url }}/network/members"> {{ .forks_count }} forks </a>{{ end }}
             &bull; <a href="{{ .html_url }}/issues">{{ .open_issues_count }} open issues</a>


### PR DESCRIPTION
For projects on GitHub which have their license specified in a way that it is not recognised or not parsed correctly by GitHub the `license.url` field retrieved from the API remains empty which caused a hugo error previously (can't `getJSON` on an empty/missing url).
Can be tested with the public projects [BAMresearch/McSAS](https://github.com/BAMresearch/McSAS) and [SASfit/SASfit](https://github.com/SASfit/SASfit).