### PR TITLE
Fix .Site.DisqusShortname deprecation error in Hugo v0.132.0.

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -30,7 +30,7 @@
           </div>
         </section>
         <br>
-        {{ if .Site.DisqusShortname -}}
+        {{ if .Site.Config.Services.Disqus.Shortname -}}
         {{ partial "disqus" . }}
         {{- end }}
       </section>

--- a/layouts/partials/sections/disqus.html
+++ b/layouts/partials/sections/disqus.html
@@ -10,7 +10,7 @@
           return;
 
       var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-      var disqus_shortname = '{{ .Site.DisqusShortname }}';
+      var disqus_shortname = '{{ .Site.Config.Services.Disqus.Shortname }}';
       dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
       (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
   })();


### PR DESCRIPTION
Adjusted Disqus shortname calls in templates to conform to new Hugo site data structure.

Like #54 the deprecation warning became an error due to upcoming deprecation in v0.133.0.

Tested on Hugo v0.132.0.